### PR TITLE
Teardown and destroy-db -y/--yes flags implemented

### DIFF
--- a/src/commands/destroydb.js
+++ b/src/commands/destroydb.js
@@ -1,8 +1,8 @@
 const { startDatabaseDeletion } = require("../utilities/destroydbCommand.js");
 
-function destroydb() {
+function destroydb(options) {
   (async () => {
-    await startDatabaseDeletion();
+    await startDatabaseDeletion(options);
   })();
 }
 

--- a/src/commands/teardown.js
+++ b/src/commands/teardown.js
@@ -1,8 +1,8 @@
-const { startTeardown } = require('../utilities/teardownCommand.js');
+const { startTeardown } = require("../utilities/teardownCommand.js");
 
-function teardown() {
+function teardown(options) {
   (async () => {
-    await startTeardown();
+    await startTeardown(options);
   })();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,55 +1,58 @@
 #!/usr/bin/env node
 
-const cli = require('commander');
-const start = require('./commands/start.js');
-const startGrafana = require('./commands/startGrafana.js');
-const stopGrafana = require('./commands/stopGrafana.js');
-const deploy = require('./commands/deploy.js');
-const teardown = require('./commands/teardown.js');
-const sleep = require('./commands/sleep.js');
-const destroyDb = require('./commands/destroydb.js');
+const cli = require("commander");
+const start = require("./commands/start.js");
+const startGrafana = require("./commands/startGrafana.js");
+const stopGrafana = require("./commands/stopGrafana.js");
+const deploy = require("./commands/deploy.js");
+const teardown = require("./commands/teardown.js");
+const sleep = require("./commands/sleep.js");
+const destroyDb = require("./commands/destroydb.js");
 
-cli.description('Artemis API Load Testing CLI');
-cli.name('artemis');
+cli.description("Artemis API Load Testing CLI");
+cli.name("artemis");
 
 cli
-  .command('run-test')
-  .requiredOption('-tc, --taskCount <number>', 'Task count.')
-  .requiredOption('-p, --path <path>', 'Relative path to test script file')
-  .description('Run the test script concurrently this number of times.')
+  .command("run-test")
+  .requiredOption("-tc, --taskCount <number>", "Task count.")
+  .requiredOption("-p, --path <path>", "Relative path to test script file")
+  .description("Run the test script concurrently this number of times.")
   .action(start);
+
 cli
-  .command('grafana-start')
-  .description('Start the Artemis Grafana dashboard.')
+  .command("grafana-start")
+  .description("Start the Artemis Grafana dashboard.")
   .action(startGrafana);
 
 cli
-  .command('grafana-stop')
-  .description('Stop the Artemis Grafana dashboard.')
+  .command("grafana-stop")
+  .description("Stop the Artemis Grafana dashboard.")
   .action(stopGrafana);
 
 cli
-  .command('deploy')
+  .command("deploy")
   .description("Deploy Artemis infrastructure on the user's AWS account.")
   .action(deploy);
 
 cli
-  .command('sleep')
+  .command("sleep")
   .description(
-    'Stop all support container tasks for minimal AWS usage charges.'
+    "Stop all support container tasks for minimal AWS usage charges."
   )
   .action(sleep);
 
 cli
-  .command('teardown')
+  .command("teardown")
+  .option("-y, --yes", "Execute teardown without user confirmation.")
   .description(
     "Teardown Artemis infrastructure on user's AWS account, retain Artemis database."
   )
   .action(teardown);
 
 cli
-  .command('destroy-db')
-  .description('Delete the Artemis database.')
+  .command("destroy-db")
+  .option("-y, --yes", "Execute destroy database without user confirmation.")
+  .description("Delete the Artemis database.")
   .action(destroyDb);
 
 cli.parse(process.argv);

--- a/src/utilities/destroydbCommand.js
+++ b/src/utilities/destroydbCommand.js
@@ -1,15 +1,15 @@
-const AWS = require('aws-sdk');
-const execSync = require('child_process').execSync;
-const userRegion = execSync('aws configure get region').toString().trim();
+const AWS = require("aws-sdk");
+const execSync = require("child_process").execSync;
+const userRegion = execSync("aws configure get region").toString().trim();
 AWS.config.update({ region: userRegion });
 const timestreamwrite = new AWS.TimestreamWrite();
-const timestreamDbName = 'artemis-db';
-const fs = require('fs');
-const path = require('path');
-const cdkPath = path.join(__dirname, '../aws');
-const ora = require('ora-classic');
-const chalk = require('chalk');
-const readlineSync = require('readline-sync');
+const timestreamDbName = "artemis-db";
+const fs = require("fs");
+const path = require("path");
+const cdkPath = path.join(__dirname, "../aws");
+const ora = require("ora-classic");
+const chalk = require("chalk");
+const readlineSync = require("readline-sync");
 
 const pause = (time) => {
   return new Promise((resolve) => setTimeout(resolve, time)); // in ms
@@ -21,7 +21,7 @@ const setFirstDeployToTrue = async () => {
     if (err) console.log(err);
     else {
       let firstDeployStatus = JSON.parse(
-        fs.readFileSync(`${cdkPath}/config.json`, 'utf8')
+        fs.readFileSync(`${cdkPath}/config.json`, "utf8")
       ).firstDeploy;
     }
   });
@@ -49,7 +49,7 @@ const deleteTables = async (dbName, tables) => {
     spinner = ora(
       chalk.cyan(`Deleting ${table.TableName} table of ${dbName} database...`)
     ).start();
-    spinner.color = 'yellow';
+    spinner.color = "yellow";
     await deleteTable(dbName, table.TableName);
     spinner.succeed(
       chalk.cyan(`${table.TableName} table of ${dbName} has been deleted.`)
@@ -61,7 +61,7 @@ const deleteDatabase = async (dbName) => {
   const spinner = ora(
     chalk.cyan(`Deleting ${timestreamDbName} database...`)
   ).start();
-  spinner.color = 'yellow';
+  spinner.color = "yellow";
 
   await timestreamwrite
     .deleteDatabase({
@@ -95,35 +95,40 @@ const deleteTablesAndDatabase = async () => {
   }
 };
 
-const startDatabaseDeletion = async () => {
-  const USER_INPUT = ['y', 'n', 'yes', 'no'];
+const startDatabaseDeletion = async (options) => {
+  const USER_INPUT = ["y", "n", "yes", "no"];
   let confirmDbDelete;
 
-  do {
-    confirmDbDelete = readlineSync.question(
-      chalk.cyan(
-        'Are you sure you want to delete the Artemis database? (y/n)\n'
-      )
-    );
-    confirmDbDelete = confirmDbDelete.toLowerCase().trim();
+  if (options.yes) {
+    await deleteTablesAndDatabase();
+    await setFirstDeployToTrue();
+  } else {
+    do {
+      confirmDbDelete = readlineSync.question(
+        chalk.cyan(
+          "Are you sure you want to delete the Artemis database? (y/n)\n"
+        )
+      );
+      confirmDbDelete = confirmDbDelete.toLowerCase().trim();
 
-    if (
-      USER_INPUT.includes(confirmDbDelete) &&
-      confirmDbDelete.startsWith('y')
-    ) {
-      await deleteTablesAndDatabase();
-      await setFirstDeployToTrue();
-    } else if (
-      USER_INPUT.includes(confirmDbDelete) &&
-      confirmDbDelete.startsWith('n')
-    ) {
-      console.log(chalk.yellow('Database deletion canceled.'));
-    } else {
-      console.log(chalk.cyan('Please provide the correct input.'));
-      await pause(1500);
-      console.clear();
-    }
-  } while (!USER_INPUT.includes(confirmDbDelete));
+      if (
+        USER_INPUT.includes(confirmDbDelete) &&
+        confirmDbDelete.startsWith("y")
+      ) {
+        await deleteTablesAndDatabase();
+        await setFirstDeployToTrue();
+      } else if (
+        USER_INPUT.includes(confirmDbDelete) &&
+        confirmDbDelete.startsWith("n")
+      ) {
+        console.log(chalk.yellow("Database deletion canceled."));
+      } else {
+        console.log(chalk.cyan("Please provide the correct input."));
+        await pause(1500);
+        console.clear();
+      }
+    } while (!USER_INPUT.includes(confirmDbDelete));
+  }
 };
 
 module.exports = { startDatabaseDeletion };

--- a/src/utilities/teardownCommand.js
+++ b/src/utilities/teardownCommand.js
@@ -1,56 +1,58 @@
-const AWS = require("aws-sdk");
-const execSync = require("child_process").execSync;
-const userRegion = execSync("aws configure get region").toString().trim();
-const readlineSync = require("readline-sync");
-const ora = require("ora-classic");
-const chalk = require("chalk");
+const AWS = require('aws-sdk');
+const execSync = require('child_process').execSync;
+const userRegion = execSync('aws configure get region').toString().trim();
+const readlineSync = require('readline-sync');
+const ora = require('ora-classic');
+const chalk = require('chalk');
 AWS.config.update({ region: userRegion });
-const path = require("path");
+const path = require('path');
 
-const { promisify } = require("util");
-const sleep = require("../commands/sleep.js");
-const exec = promisify(require("child_process").exec);
+const { promisify } = require('util');
+const sleep = require('../commands/sleep.js');
+const exec = promisify(require('child_process').exec);
 
-const cdkPathEscaped = path.join(__dirname, "../aws").replace(/ /g, "\\ ");
+const cdkPathEscaped = path.join(__dirname, '../aws').replace(/ /g, '\\ ');
 
 const pause = (time) => {
   return new Promise((resolve) => setTimeout(resolve, time)); // in ms
 };
 
+const executeTeardown = async () => {
+  await sleep();
+  const spinner = ora(chalk.cyan('Teardown in progress...')).start();
+  spinner.color = 'yellow';
+
+  await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
+    encoding: 'utf-8',
+  });
+  spinner.succeed(chalk.cyan('Teardown completed successfully.'));
+};
+
 const startTeardown = async (options) => {
-  const USER_INPUT = ["y", "n", "yes", "no"];
+  const USER_INPUT = ['y', 'n', 'yes', 'no'];
   let confirmTeardown;
 
   if (options.yes) {
-    await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
-      encoding: "utf-8",
-    });
+    await executeTeardown();
   } else {
     do {
       confirmTeardown = readlineSync.question(
-        chalk.cyan("Are you sure you want to perform a teardown? (y/n)\n")
+        chalk.cyan('Are you sure you want to perform a teardown? (y/n)\n')
       );
       confirmTeardown = confirmTeardown.toLowerCase().trim();
 
       if (
         USER_INPUT.includes(confirmTeardown) &&
-        confirmTeardown.startsWith("y")
+        confirmTeardown.startsWith('y')
       ) {
-        await sleep();
-        const spinner = ora(chalk.cyan("Teardown in progress...")).start();
-        spinner.color = "yellow";
-
-        await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
-          encoding: "utf-8",
-        });
-        spinner.succeed(chalk.cyan("Teardown completed successfully."));
+        await executeTeardown();
       } else if (
         USER_INPUT.includes(confirmTeardown) &&
-        confirmTeardown.startsWith("n")
+        confirmTeardown.startsWith('n')
       ) {
-        console.log(chalk.yellow("Teardown canceled."));
+        console.log(chalk.yellow('Teardown canceled.'));
       } else {
-        console.log(chalk.cyan("Please provide the correct input."));
+        console.log(chalk.cyan('Please provide the correct input.'));
         await pause(1500);
         console.clear();
       }

--- a/src/utilities/teardownCommand.js
+++ b/src/utilities/teardownCommand.js
@@ -17,39 +17,45 @@ const pause = (time) => {
   return new Promise((resolve) => setTimeout(resolve, time)); // in ms
 };
 
-const startTeardown = async () => {
+const startTeardown = async (options) => {
   const USER_INPUT = ["y", "n", "yes", "no"];
   let confirmTeardown;
 
-  do {
-    confirmTeardown = readlineSync.question(
-      chalk.cyan("Are you sure you want to perform a teardown? (y/n)\n")
-    );
-    confirmTeardown = confirmTeardown.toLowerCase().trim();
+  if (options.yes) {
+    await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
+      encoding: "utf-8",
+    });
+  } else {
+    do {
+      confirmTeardown = readlineSync.question(
+        chalk.cyan("Are you sure you want to perform a teardown? (y/n)\n")
+      );
+      confirmTeardown = confirmTeardown.toLowerCase().trim();
 
-    if (
-      USER_INPUT.includes(confirmTeardown) &&
-      confirmTeardown.startsWith("y")
-    ) {
-      await sleep();
-      const spinner = ora(chalk.cyan("Teardown in progress...")).start();
-      spinner.color = "yellow";
+      if (
+        USER_INPUT.includes(confirmTeardown) &&
+        confirmTeardown.startsWith("y")
+      ) {
+        await sleep();
+        const spinner = ora(chalk.cyan("Teardown in progress...")).start();
+        spinner.color = "yellow";
 
-      await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
-        encoding: "utf-8",
-      });
-      spinner.succeed(chalk.cyan("Teardown completed successfully."));
-    } else if (
-      USER_INPUT.includes(confirmTeardown) &&
-      confirmTeardown.startsWith("n")
-    ) {
-      console.log(chalk.yellow("Teardown canceled."));
-    } else {
-      console.log(chalk.cyan("Please provide the correct input."));
-      await pause(1500);
-      console.clear();
-    }
-  } while (!USER_INPUT.includes(confirmTeardown));
+        await exec(`cd ${cdkPathEscaped} && cdk destroy -f`, {
+          encoding: "utf-8",
+        });
+        spinner.succeed(chalk.cyan("Teardown completed successfully."));
+      } else if (
+        USER_INPUT.includes(confirmTeardown) &&
+        confirmTeardown.startsWith("n")
+      ) {
+        console.log(chalk.yellow("Teardown canceled."));
+      } else {
+        console.log(chalk.cyan("Please provide the correct input."));
+        await pause(1500);
+        console.clear();
+      }
+    } while (!USER_INPUT.includes(confirmTeardown));
+  }
 };
 
 module.exports = { startTeardown };


### PR DESCRIPTION
--yes -y optional flags added to these two commands to enable future GUI admin dashboard to easily interface with the CLI and bypass command line user confirmation, admin dashboard should implement its own confirmation from user before calling either of these commands with the -y or --yes flag.

I have tested this. Raul has tested this.

Note, many little diffs because prettier changes ' to ", etc. We should all be using prettier uniformly (default config is fine) so the same styles get committed from the beginning.